### PR TITLE
Fixes 'count-to' module not found error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Include the javascript file.
 Inject the `count-to` directive in your app.
 
 ```
-var myApp = angular.module('myApp', ['count-to']);
+var myApp = angular.module('myApp', ['countTo']);
 ```
 
 Apply the directive to a dom element.


### PR DESCRIPTION
Module is declared as 'countTo' but loaded as 'count-to'. Should be 

```
var myApp = angular.module('myApp', ['countTo']);
```